### PR TITLE
Close mqtt client even if disconnect to terminate reconnect thread

### DIFF
--- a/src/clients/BaseClient.js
+++ b/src/clients/BaseClient.js
@@ -117,6 +117,11 @@ export default class BaseClient extends events.EventEmitter {
 
   disconnect(){
     if(!this.isConnected){
+      if (this.mqtt) {
+          // The client is disconnected, but the reconnect thread
+          // is running. Need to stop it.
+          this.mqtt.end(true, () => {});
+      }
       throw new Error("Client is not connected");
     }
 


### PR DESCRIPTION
If you 'disconnect' a client when it is already disconnected, we are not stopping the reconnect thread of the client. So whilst the application believes the client to now be disconnected, it is still trying to reconnect in the background.