### PR TITLE
Use the new URL for HTTP messaging

### DIFF
--- a/src/clients/ApplicationClient.js
+++ b/src/clients/ApplicationClient.js
@@ -635,7 +635,7 @@ export default class ApplicationClient extends BaseClient {
     this.log.debug("[ApplicationClient:publishHTTPS] Publishing event of Type: "+ eventType + " with payload : "+payload);
     return new Promise((resolve, reject) => {
 
-      let uri = format("https://%s.%s/api/v0002/device/types/%s/devices/%s/events/%s", this.org, this.domainName, deviceType, deviceId, eventType);
+      let uri = format("https://%s.messaging.%s/api/v0002/device/types/%s/devices/%s/events/%s", this.org, this.domainName, deviceType, deviceId, eventType);
 
 
       let xhrConfig = {


### PR DESCRIPTION
Looks like the application client case is not using the new HTTP URL @jeffdare ?