### PR TITLE
Fixed missing value for mqtt-server

### DIFF
--- a/dist/clients/BaseClient.js
+++ b/dist/clients/BaseClient.js
@@ -90,8 +90,10 @@
         }
         this.mqttServer = config.org + ".messaging." + config.domain;
         this.domainName = config.domain;
+        config['mqtt-server'] = this.mqttServer;
       } else {
         this.mqttServer = config.org + ".messaging.internetofthings.ibmcloud.com";
+        config['mqtt-server'] = this.mqttServer;
       }
 
       //property to enforce Websockets even in Node

--- a/src/clients/BaseClient.js
+++ b/src/clients/BaseClient.js
@@ -63,8 +63,10 @@ export default class BaseClient extends events.EventEmitter {
         }
         this.mqttServer = config.org + ".messaging." + config.domain;
         this.domainName = config.domain;
+        config['mqtt-server'] = this.mqttServer;
     } else {
         this.mqttServer = config.org + ".messaging.internetofthings.ibmcloud.com";
+        config['mqtt-server'] = this.mqttServer;
    }
 
     //property to enforce Websockets even in Node 


### PR DESCRIPTION
The fix contains the addition of mqtt-server value to config when we don't have specified either from property file or present in config. This was causing mqttConfig.servername to be undefined when we use Client Side Certificates with Node.js.