### PR TITLE
This commit is fix for the auto reconnect logic for wrong credentials.

### DIFF
--- a/dist/clients/BaseClient.js
+++ b/dist/clients/BaseClient.js
@@ -203,7 +203,7 @@
           _this.isConnected = false;
           var errorMsg = '' + error;
           if (errorMsg.indexOf('Not authorized') > -1) {
-            _this.log.error("[BaseClient:onError] One or more connection parameters is wrong. Update the configuration and try again.");
+            _this.log.error("[BaseClient:onError] One or more connection parameters are wrong. Update the configuration and try again.");
             _this.mqtt.reconnecting = false;
             _this.mqtt.options.reconnectPeriod = 0;
           }

--- a/dist/clients/BaseClient.js
+++ b/dist/clients/BaseClient.js
@@ -201,6 +201,12 @@
         this.mqtt.on('error', function (error) {
           _this.log.error("[BaseClient:onError] Connection Error :: " + error);
           _this.isConnected = false;
+          var errorMsg = '' + error;
+          if (errorMsg.indexOf('Not authorized') > -1) {
+            _this.log.error("[BaseClient:onError] One or more connection parameters is wrong. Update the configuration and try again.");
+            _this.mqtt.reconnecting = false;
+            _this.mqtt.options.reconnectPeriod = 0;
+          }
           _this.emit('error', error);
         });
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
         "name": "ibmiotf",
-        "version": "0.2.37",
+        "version": "0.2.38",
         "description": "A library for developing device and application clients for IBM Watson IoT Platform",
         "main": "dist/iotf-client.js",
         "dependencies": {

--- a/src/clients/BaseClient.js
+++ b/src/clients/BaseClient.js
@@ -160,6 +160,12 @@ export default class BaseClient extends events.EventEmitter {
     this.mqtt.on('error', (error) => {
       this.log.error("[BaseClient:onError] Connection Error :: "+error);
       this.isConnected = false;
+      let errorMsg = ''+error;
+      if(errorMsg.indexOf('Not authorized') > -1) {
+        this.log.error("[BaseClient:onError] One or more connection parameters is wrong. Update the configuration and try again.");
+        this.mqtt.reconnecting = false;
+        this.mqtt.options.reconnectPeriod = 0;
+      }
       this.emit('error', error);
     });
   }

--- a/src/clients/BaseClient.js
+++ b/src/clients/BaseClient.js
@@ -162,7 +162,7 @@ export default class BaseClient extends events.EventEmitter {
       this.isConnected = false;
       let errorMsg = ''+error;
       if(errorMsg.indexOf('Not authorized') > -1) {
-        this.log.error("[BaseClient:onError] One or more connection parameters is wrong. Update the configuration and try again.");
+        this.log.error("[BaseClient:onError] One or more connection parameters are wrong. Update the configuration and try again.");
         this.mqtt.reconnecting = false;
         this.mqtt.options.reconnectPeriod = 0;
       }


### PR DESCRIPTION
Before, if the credentials provided(deviceID, deviceType or Token) were wrong, the client still tries to reconnect. Now the client will not attempt to reconnect if the credentials are wrong.

Fixes #22