### PR TITLE
ignore package-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ coverage
 .DS_Store
 dist/iotf-client-bundle.js
 dist/iotf-client-bundle.min.js
+package-lock.json


### PR DESCRIPTION
This PR ignores the lockfile created by npm@5.

The lockfile is not distributed in a published npm package; this means that only those cloning this  repo have will use the lockfile.  When `npm install` is run in a working copy, the dependencies are fixed to the lockfile, which is *not necessarily the same* as the dependencies which an end user would receive via `npm install ibmiotf`.  

Committing the lockfile to VCS would then have the potential to cause problems reproducing bugs for those maintaining this library.