### PR TITLE
remove unused auth-method option

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,11 +80,9 @@ configuration JSON containing the following:
 -   org - Your organization ID
 -   type - The type of your device
 -   id - The ID of your device
--   auth-method - Method of authentication (the only value currently
-    supported is “token”)
--   auth-token - API key token (required if auth-method is “token”)
--   domain - (Optional)The messaging endpoint URL. By default, the value is "internetofthings.ibmcloud.com"(Watson IoT Production server).
--   enforce-ws - (Optional)Enforce Websocket when using the library in Node.js
+-   auth-token - API key token
+-   domain - (Optional) The messaging endpoint URL. By default, the value is "internetofthings.ibmcloud.com"(Watson IoT Production server).
+-   enforce-ws - (Optional) Enforce Websocket when using the library in Node.js
 -   use-client-certs - (Optional) Enforces use of client side certificates when specified as true
 -   server-ca - (Optional) Specifies the custom server certificate signed using device key
 -   client-ca - (Mandatory when use-client-certs:true) Specifies the path to device-client CA certificate

--- a/src/clients/DeviceClient.js
+++ b/src/clients/DeviceClient.js
@@ -38,16 +38,6 @@ export default class DeviceClient extends BaseClient {
     }
 
     if(config.org !== QUICKSTART_ORG_ID){
-      if(!isDefined(config['auth-method'])){
-        throw new Error('[DeviceClient:constructor] config must contain auth-method');
-      }
-      else if(!isString(config['auth-method'])){
-        throw new Error('[DeviceClient:constructor] auth-method must be a string');
-      }
-      else if(config['auth-method'] !== 'token'){
-        throw new Error('[DeviceClient:constructor] unsupported authentication method' + config['auth-method']);
-      }
-
       this.mqttConfig.username = 'use-token-auth';
     }
 

--- a/src/clients/GatewayClient.js
+++ b/src/clients/GatewayClient.js
@@ -40,16 +40,6 @@ export default class GatewayClient extends BaseClient {
       throw new Error('[GatewayClient:constructor] Quickstart not supported in Gateways');
     }
 
-    if(!isDefined(config['auth-method'])){
-      throw new Error('[GatewayClient:constructor] config must contain auth-method');
-    }
-    else if(!isString(config['auth-method'])){
-      throw new Error('[GatewayClient:constructor] auth-method must be a string');
-    }
-    else if(config['auth-method'] !== 'token'){
-      throw new Error('[GatewayClient:constructor] unsupported authentication method' + config['auth-method']);
-    }
-
     this.mqttConfig.username = 'use-token-auth';
 
     this.org = config.org;

--- a/test/DeviceClient.spec.js
+++ b/test/DeviceClient.spec.js
@@ -87,26 +87,6 @@ describe('IotfDevice', () => {
         }).to.throw(/config must contain type/);
       });
 
-      it('should throw an error if auth-method is not present', () => {
-        expect(() => {
-          let client = new IBMIoTF.IotfDevice({org:'regorg', id:'123', 'auth-token': '123', 'type': '123'});
-        }).to.throw(/config must contain auth-method/);
-      });
-
-      it('should throw an error if auth-method is not "token"', () => {
-        expect(() => {
-          let client = new IBMIoTF.IotfDevice({org:'regorg', id:'123', 'auth-token': '123', 'type': '123', 'auth-method': 'abc'});
-        }).to.throw(/unsupported authentication method/);
-      });
-
-      it('should throw an error if auth-method is not "token"', () => {
-        let client;
-        expect(() => {
-          client = new IBMIoTF.IotfDevice({org:'regorg', id:'123', 'auth-token': '123', 'type': '123', 'auth-method': 'token'});
-        }).not.to.throw();
-        expect(client).to.be.instanceof(IBMIoTF.IotfDevice);
-      });
-
       it('should run in registered mode if org is not set to "quickstart"', () => {
         let client = new IBMIoTF.IotfDevice({org: 'qs', type: 'mytype', id: '3215', 'auth-method': 'token', 'auth-token': 'abc'});
         expect(client.isQuickstart).to.equal(false);

--- a/test/GatewayClient.spec.js
+++ b/test/GatewayClient.spec.js
@@ -64,24 +64,6 @@ describe('IotfGateway', () => {
         }).to.throw(/type must be a string/);
       });
 
-      it('should throw an error if auth-method is not present', () => {
-        expect(() => {
-          let client = new IBMIoTF.IotfGateway({org:'regorg', id:'123', 'auth-token': '123', 'type': '123'});
-        }).to.throw(/config must contain auth-method/);
-      });
-
-      it('should throw an error if auth-method is not string', () => {
-        expect(() => {
-          let client = new IBMIoTF.IotfGateway({org:'regorg', id:'123', 'auth-token': '123', 'type': '123', 'auth-method': 123});
-        }).to.throw(/auth-method must be a string/);
-      });
-
-      it('should throw an error if auth-method is not "token"', () => {
-        expect(() => {
-          let client = new IBMIoTF.IotfGateway({org:'regorg', id:'123', 'auth-token': '123', 'type': '123', 'auth-method': 'abc'});
-        }).to.throw(/unsupported authentication method/);
-      });
-
       it('should throw an error if org is set to quickstart', () => {
         expect(() => {
           let client = new IBMIoTF.IotfGateway({org:'quickstart', id:'123', 'auth-token': '123', 'type': '123', 'auth-method': 'abc'});

--- a/test/ManagedDeviceClient.spec.js
+++ b/test/ManagedDeviceClient.spec.js
@@ -54,18 +54,6 @@ describe('IotfManagedDevice', () => {
         }).to.throw(/config must contain type/);
       });
 
-      it('should throw an error if auth-method is not present', () => {
-        expect(() => {
-          let client = new IBMIoTF.IotfManagedDevice({org:'regorg', id:'123', 'auth-token': '123', 'type': '123'});
-        }).to.throw(/config must contain auth-method/);
-      });
-
-      it('should throw an error if auth-method is not "token"', () => {
-        expect(() => {
-          let client = new IBMIoTF.IotfManagedDevice({org:'regorg', id:'123', 'auth-token': '123', 'type': '123', 'auth-method': 'abc'});
-        }).to.throw(/unsupported authentication method/);
-      });
-
       it('should return an instance if org, id and type are specified', () => {
         let client;
         expect(() => {

--- a/test/ManagedGatewayClient.spec.js
+++ b/test/ManagedGatewayClient.spec.js
@@ -54,18 +54,6 @@ describe('IotfManagedGateway', () => {
         }).to.throw(/config must contain type/);
       });
 
-      it('should throw an error if auth-method is not present', () => {
-        expect(() => {
-          let client = new IBMIoTF.IotfManagedGateway({org:'regorg', id:'123', 'auth-token': '123', 'type': '123'});
-        }).to.throw(/config must contain auth-method/);
-      });
-
-      it('should throw an error if auth-method is not "token"', () => {
-        expect(() => {
-          let client = new IBMIoTF.IotfManagedGateway({org:'regorg', id:'123', 'auth-token': '123', 'type': '123', 'auth-method': 'abc'});
-        }).to.throw(/unsupported authentication method/);
-      });
-
       it('should return an instance if org, id and type are specified', () => {
         let client;
         expect(() => {


### PR DESCRIPTION
It's not the greatest DX for a user to supply a required option if that option is both required *and* a constant.  There's no reason why this library couldn't simply default to `token` for the value.

But since the option is completely *unused*, it doesn't make sense for it to exist.  It becomes overhead for the consumer of this library.

If/when `auth-method` needs to be an enumerated type (`token`, `something`, `something-else`), it can be re-added.  At that time, a *default* should be chosen.