### PR TITLE
Support for unsecure certificate validation

### DIFF
--- a/src/util/util.js
+++ b/src/util/util.js
@@ -43,7 +43,7 @@ export function generateUUID() {
 export function initializeMqttConfig(config){
   var mqttConfig = {
      password: config['auth-token'],
-     rejectUnauthorized : true
+     rejectUnauthorized: (config['reject-unauthorized']) ? config['reject-unauthorized'] : true
   };
   if(config['use-client-certs'] == true || config['use-client-certs'] == "true"){
     var serverCA = fs.readFileSync(__dirname + '/IoTFoundation.pem');


### PR DESCRIPTION
This helps greatly when using the library under certain circumstances or for development and testing.
As example, under Windows and behind a firewall which substitutes the certificate with its own, even if the CA Root is trusted the library will always reject the cert because is not trusted.

Default value will always be true to allow only trusted certs.

Needs tests and documentation written to be used in a proper way.