### PR TITLE
Adding abiltity to alter MQTT version using either envVars or ConfigFile

### DIFF
--- a/src/BaseConfig.js
+++ b/src/BaseConfig.js
@@ -66,6 +66,10 @@ export default class BaseConfig{
         if (!("caFile" in this.options.mqtt)) {
             this.options.mqtt.caFile = null;
         }    
+
+        if (!("protocolVersion" in this.options.mqtt)) {
+            this.options.mqtt.protocolVersion = 4;
+        }    
     }
 
     getOrgId() {
@@ -113,9 +117,9 @@ export default class BaseConfig{
             // is not recommended for production environments.
             rejectUnauthorized: true,
 
-            // MQTTv5 support doesn't work with Watson IoT Platform, so stick to default for now
-            // protocolId: "MQTT",
-            // protocolVersion: 5
+            //MQTT version support - MQTTv5 is currently unavailable to use due to the the mqtt.js module 
+            protocolId: "MQTT",
+            protocolVersion: this.options.mqtt.protocolVersion
         }
         return mqttConfig;
     }

--- a/src/application/ApplicationConfig.js
+++ b/src/application/ApplicationConfig.js
@@ -95,6 +95,7 @@ export default class ApplicationConfig  extends BaseConfig{
         let port = process.env.WIOTP_OPTIONS_MQTT_PORT || null;
         let transport = process.env.WIOTP_OPTIONS_MQTT_TRANSPORT || null;
         let caFile = process.env.WIOTP_OPTIONS_MQTT_CAFILE || null;
+        let protocolVersion = process.env.WIOTP_OPTIONS_MQTT_VERSION || 4;
         let cleanStart = process.env.WIOTP_OPTIONS_MQTT_CLEANSTART || "true";
         let sessionExpiry = process.env.WIOTP_OPTIONS_MQTT_SESSIONEXPIRY || 3600;
         let keepAlive = process.env.WIOTP_OPTIONS_MQTT_KEEPALIVE || 60;
@@ -106,7 +107,8 @@ export default class ApplicationConfig  extends BaseConfig{
             port = parseInt(port);
         }
         sessionExpiry = parseInt(sessionExpiry);
-        keepAlive = parseInt(keepAlive)
+        keepAlive = parseInt(keepAlive);
+        protocolVersion = parseInt(protocolVersion);
     
         let identity = {appId: appId};
         let options = {
@@ -120,6 +122,7 @@ export default class ApplicationConfig  extends BaseConfig{
                 keepAlive: keepAlive,
                 sharedSubscription: (["True", "true", "1"].includes(sharedSubs)),
                 caFile: caFile,
+                protocolVersion: protocolVersion
             },
             http: {
                 verify: (["True", "true", "1"].includes(verifyCert))
@@ -155,6 +158,7 @@ export default class ApplicationConfig  extends BaseConfig{
                 sessionExpiry: 3600
                 keepAlive: 60
                 caFile: /path/to/certificateAuthorityFile.pem
+                protocolVersion: 4
             http:
                 verify: true  
         */  

--- a/src/device/DeviceConfig.js
+++ b/src/device/DeviceConfig.js
@@ -84,6 +84,7 @@ export default class DeviceConfig extends BaseConfig{
         let port = process.env.WIOTP_OPTIONS_MQTT_PORT || null;
         let transport = process.env.WIOTP_OPTIONS_MQTT_TRANSPORT || null;
         let caFile = process.env.WIOTP_OPTIONS_MQTT_CAFILE || null;
+        let protocolVersion = process.env.WIOTP_OPTIONS_MQTT_VERSION || 4;
         let cleanStart = process.env.WIOTP_OPTIONS_MQTT_CLEANSTART || "true";
         let sessionExpiry = process.env.WIOTP_OPTIONS_MQTT_SESSIONEXPIRY || 3600;
         let keepAlive = process.env.WIOTP_OPTIONS_MQTT_KEEPALIVE || 60;
@@ -94,7 +95,8 @@ export default class DeviceConfig extends BaseConfig{
             port = parseInt(port);
         }
         sessionExpiry = parseInt(sessionExpiry);
-        keepAlive = parseInt(keepAlive)
+        keepAlive = parseInt(keepAlive);
+        protocolVersion = parseInt(protocolVersion);
     
         let identity = {orgId:orgId, typeId: typeId, deviceId:deviceId};
         let options = {
@@ -108,6 +110,7 @@ export default class DeviceConfig extends BaseConfig{
                 keepAlive: keepAlive,
                 sharedSubscription: (["True", "true", "1"].includes(sharedSubs)),
                 caFile: caFile,
+                protocolVersion: protocolVersion,
             },
         };
         let auth = null;
@@ -140,6 +143,7 @@ export default class DeviceConfig extends BaseConfig{
                 sessionExpiry: 3600
                 keepAlive: 60
                 caFile: /path/to/certificateAuthorityFile.pem
+                protocolVersion: 4
         */  
 
         const configFile = fs.readFileSync(configFilePath, 'utf8');

--- a/test/ApplicationConfig.spec.js
+++ b/test/ApplicationConfig.spec.js
@@ -53,6 +53,7 @@ describe('WIoTP Application Configuration', () => {
     expect(config.options.mqtt.sessionExpiry).to.equal(3600);
     expect(config.options.mqtt.keepAlive).to.equal(60);
     expect(config.options.mqtt.caFile).to.equal("myPath");
+    expect(config.options.mqtt.protocolVersion).to.equal(4);
     expect(config.options.http.verify).to.equal(true);
   });
 

--- a/test/ApplicationConfigFile.spec.yaml
+++ b/test/ApplicationConfigFile.spec.yaml
@@ -15,5 +15,6 @@
         sessionExpiry: 3600
         keepAlive: 60
         caFile: myPath
+        protocolVersion: 4
       http:
         verify: true    

--- a/test/DeviceConfig.spec.js
+++ b/test/DeviceConfig.spec.js
@@ -56,6 +56,7 @@ describe('WIoTP Device Configuration', () => {
     expect(config.options.mqtt.sessionExpiry).to.equal(3600);
     expect(config.options.mqtt.keepAlive).to.equal(60);
     expect(config.options.mqtt.caFile).to.equal("myPath");
+    expect(config.options.mqtt.protocolVersion).to.equal(4);
   });
 
 });

--- a/test/DeviceConfigFile.spec.yaml
+++ b/test/DeviceConfigFile.spec.yaml
@@ -15,3 +15,4 @@
         sessionExpiry: 3600
         keepAlive: 60
         caFile: myPath
+        protocolVersion: 4


### PR DESCRIPTION
May be redundant due to the current inability to use MQTTv5 but this way we're ready for the node update if we wanted to be.