### PR TITLE
#142 correcting sharedsubscription call

### DIFF
--- a/src/application/ApplicationConfig.js
+++ b/src/application/ApplicationConfig.js
@@ -61,7 +61,7 @@ export default class ApplicationConfig  extends BaseConfig{
 
     getClientId() {
         let clientIdPrefix = "a";
-        if (this.sharedSubscription == true) {
+        if (this.options.mqtt.sharedSubscription == true) {
             clientIdPrefix = "A";
         }
         return clientIdPrefix + ":" + this.getOrgId() + ":" + this.identity.appId;


### PR DESCRIPTION
Correcting from a call of `this.sharedSubscription` to `this.options.mqtt.sharedSubscription`