### PR TITLE
Monitoring dashboard updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiotp/sdk",
-  "version": "0.7.4-pre.monitoring-dashboard-updates",
+  "version": "0.7.5-pre.monitoring-dashboard-updates",
   "description": "SDK for developing device, gateway, and application clients for IBM Watson IoT Platform",
   "main": "dist/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiotp/sdk",
-  "version": "0.7.5-pre.monitoring-dashboard-updates",
+  "version": "0.7.6-pre.monitoring-dashboard-updates",
   "description": "SDK for developing device, gateway, and application clients for IBM Watson IoT Platform",
   "main": "dist/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiotp/sdk",
-  "version": "0.6.2",
+  "version": "0.7.1-pre.monitoring-dashboard-updates",
   "description": "SDK for developing device, gateway, and application clients for IBM Watson IoT Platform",
   "main": "dist/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiotp/sdk",
-  "version": "0.7.2-pre.monitoring-dashboard-updates",
+  "version": "0.7.3-pre.monitoring-dashboard-updates",
   "description": "SDK for developing device, gateway, and application clients for IBM Watson IoT Platform",
   "main": "dist/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiotp/sdk",
-  "version": "0.7.1-pre.monitoring-dashboard-updates",
+  "version": "0.7.2-pre.monitoring-dashboard-updates",
   "description": "SDK for developing device, gateway, and application clients for IBM Watson IoT Platform",
   "main": "dist/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiotp/sdk",
-  "version": "0.7.3-pre.monitoring-dashboard-updates",
+  "version": "0.7.4-pre.monitoring-dashboard-updates",
   "description": "SDK for developing device, gateway, and application clients for IBM Watson IoT Platform",
   "main": "dist/index.js",
   "files": [

--- a/src/api/ApiClient.js
+++ b/src/api/ApiClient.js
@@ -77,6 +77,10 @@ export default class ApiClient {
         xhrConfig.params = params;
       }
 
+      if (this.config.getAdditionalHeaders()) {
+        xhrConfig.headers = {...xhrConfig.headers, ...this.config.getAdditionalHeaders()};
+      }
+
       function transformResponse(response) {
         if (expectJsonContent && !(typeof response.data === 'object')) {
           try {

--- a/src/api/ApiClient.js
+++ b/src/api/ApiClient.js
@@ -373,6 +373,10 @@ export default class ApiClient {
         xhrConfig.params = params;
       }
 
+      if (this.config.getAdditionalHeaders()) {
+        xhrConfig.headers = {...xhrConfig.headers, ...this.config.getAdditionalHeaders()};
+      }
+
       function transformResponse(response) {
         if (response.status === expectedHttpCode) {
           if (expectJsonContent && !(typeof response.data === 'object')) {

--- a/src/api/StateClient.js
+++ b/src/api/StateClient.js
@@ -328,6 +328,15 @@ export default class StateClient {
     return this.callApi('POST', 201, true, ['device', 'types'], JSON.stringify(body));
   }
 
+
+  getDeviceTypesByLogicalInterfaceId(logicalInterfaceId, bookmark=0, limit=10) {
+    if(this.draftMode) {
+      return this.callApi('GET', 200, true, ['draft', 'device', 'types'], null, {logicalInterfaceId, '_bookmark': bookmark, '_limit': limit});
+    } else {
+      return this.callApi('GET', 200, true, ['device', 'types'], null, {'_bookmark': bookmark, '_limit': limit});
+    }
+  }
+
   createDeviceTypePhysicalInterfaceAssociation(typeId, physicalInterfaceId) {
     let body = {
       id: physicalInterfaceId

--- a/src/api/StateClient.js
+++ b/src/api/StateClient.js
@@ -282,7 +282,6 @@ export default class StateClient {
       switch(operationId) {
         case 'validate-configuration':
           return this.callApi('PATCH', 200, true, ["draft", "logicalinterfaces", logicalInterfaceId], body);
-          break
         case 'activate-configuration':
           return this.callApi('PATCH', 202, true, ["draft", "logicalinterfaces", logicalInterfaceId], body);
         case 'deactivate-configuration':
@@ -293,7 +292,7 @@ export default class StateClient {
           return this.callApi('PATCH', 200, true, ["draft", "logicalinterfaces", logicalInterfaceId], body);
       }
     } else {
-       return this.invalidOperation("PATCH operation not allowed on logical interface");
+       return this.invalidOperation("PATCH operation not allowed on active logical interface");
     }
   }  
 
@@ -311,6 +310,31 @@ export default class StateClient {
       return this.invalidOperation("PATCH operation 'deactivate-configuration' not allowed on logical interface");
     }
   }
+
+ // Application interface patch operation on draft version
+ // Acceptable operation id - validate-configuration, activate-configuration, list-differences
+ patchOperationDeviceType(deviceTypeId, operationId) {
+  var body = {
+    "operation": operationId
+  }
+
+  if(this.draftMode) {
+    switch(operationId) {
+      case 'validate-configuration':
+        return this.callApi('PATCH', 200, true, ["draft", "device", "types", deviceTypeId], body);
+      case 'activate-configuration':
+        return this.callApi('PATCH', 202, true, ["draft", "device", "types", deviceTypeId], body);
+      case 'deactivate-configuration':
+        return this.callApi('PATCH', 202, true, ["draft", "device", "types", deviceTypeId], body);
+      case 'list-differences':
+        return this.callApi('PATCH', 200, true, ["draft", "device", "types", deviceTypeId], body);
+      default:
+        return this.callApi('PATCH', 200, true, ["draft", "device", "types", deviceTypeId], body);
+    }
+  } else {
+     return this.invalidOperation("this method cannot be called when draftMode=false");
+  }
+}  
 
   // Create device type with physical Interface Id
   createDeviceType(typeId, description, deviceInfo, metadata, classId, physicalInterfaceId) {

--- a/src/application/ApplicationConfig.js
+++ b/src/application/ApplicationConfig.js
@@ -53,10 +53,15 @@ export default class ApplicationConfig  extends BaseConfig{
       }
     }
 
+    // Returns options.apiRoot if set, 'api/v0002' otherwiss
+    getApiRoot() {
+      return this.options.apiRoot || 'api/v0002';
+    }
+
     getApiBaseUri() {
       return this.auth && this.auth.useLtpa
-        ? `/api/v0002`
-        :  `https://${this.getOrgId()}.${this.options.domain}/api/v0002`;
+        ? `/${this.getApiRoot()}`
+        :  `https://${this.getOrgId()}.${this.options.domain}/${this.getApiRoot()}`;
     }
 
     getClientId() {
@@ -91,6 +96,7 @@ export default class ApplicationConfig  extends BaseConfig{
 
         // Options
         let domain = process.env.WIOTP_OPTIONS_DOMAIN || null;
+        let apiRoot = process.env.WIOTP_OPTIONS_API_ROOT || null;
         let logLevel = process.env.WIOTP_OPTIONS_LOGLEVEL || "info";
         let port = process.env.WIOTP_OPTIONS_MQTT_PORT || null;
         let transport = process.env.WIOTP_OPTIONS_MQTT_TRANSPORT || null;
@@ -111,6 +117,7 @@ export default class ApplicationConfig  extends BaseConfig{
         let identity = {appId: appId};
         let options = {
             domain: domain,
+            apiRoot: apiRoot,
             logLevel: logLevel,
             mqtt: {
                 port: port,
@@ -146,6 +153,7 @@ export default class ApplicationConfig  extends BaseConfig{
             token: Ab$76s)asj8_s5
         options:
             domain: internetofthings.ibmcloud.com
+            apiRoot: 'api/platform'
             logLevel: error|warning|info|debug
             mqtt:
                 instanceId: myInstance

--- a/src/application/ApplicationConfig.js
+++ b/src/application/ApplicationConfig.js
@@ -80,6 +80,18 @@ export default class ApplicationConfig  extends BaseConfig{
         return this.auth.token;
     }
 
+    getAdditionalHeaders() {
+      return this.options && this.options.http
+        ? this.options.http.additionalHeaders
+        : [];
+    }
+
+    setAdditionalHeader(key, value) {
+      if(!this.options.http) this.options.http = {};
+      if(!this.options.http.additionalHeaders) this.options.http.additionalHeaders = {}
+      this.options.http.additionalHeaders[key] = value;
+    }
+
     static parseEnvVars() {
         // Auth
         let authKey = process.env.WIOTP_AUTH_KEY || null;
@@ -106,6 +118,8 @@ export default class ApplicationConfig  extends BaseConfig{
         let keepAlive = process.env.WIOTP_OPTIONS_MQTT_KEEPALIVE || 60;
         let sharedSubs = process.env.WIOTP_OPTIONS_MQTT_SHAREDSUBSCRIPTION || "false";
         let verifyCert = process.env.WIOTP_OPTIONS_HTTP_VERIFY || "true";
+
+        // TODO: add environment variable parsing for options.http.additionalHeaders
     
         // String to int conversions
         if (port != null) {
@@ -164,7 +178,10 @@ export default class ApplicationConfig  extends BaseConfig{
                 keepAlive: 60
                 caFile: /path/to/certificateAuthorityFile.pem
             http:
-                verify: true  
+                verify: true
+                additionalHeaders:
+                    X-Csrf-Token: sdfsdfsdf
+                    X-myheader: hello
         */  
 
         const configFile = fs.readFileSync(configFilePath, 'utf8');

--- a/test/ApplicationConfig.spec.js
+++ b/test/ApplicationConfig.spec.js
@@ -47,6 +47,7 @@ describe('WIoTP Application Configuration', () => {
     expect(config.auth.token).to.equal("myToken")
     expect(config.options.domain).to.equal("internetofthings.ibmcloud.com");
     expect(config.options.logLevel).to.equal("info");
+    expect(config.options.apiRoot).equal('api/v0002');
     expect(config.options.mqtt.port).to.equal(8883);
     expect(config.options.mqtt.transport).to.equal("tcp");
     expect(config.options.mqtt.cleanStart).to.equal(false);
@@ -54,6 +55,7 @@ describe('WIoTP Application Configuration', () => {
     expect(config.options.mqtt.keepAlive).to.equal(60);
     expect(config.options.mqtt.caFile).to.equal("myPath");
     expect(config.options.http.verify).to.equal(true);
+    expect(config.options.http.additionalHeaders).to.deep.equal({hello: 'world', name: 'tom'});
   });
 
   it('Missing auth.key throws error', () => {

--- a/test/ApplicationConfigFile.spec.yaml
+++ b/test/ApplicationConfigFile.spec.yaml
@@ -5,6 +5,7 @@
       key: myKey
       token: myToken
     options:
+      apiRoot: api/v0002
       domain: internetofthings.ibmcloud.com
       logLevel: info
       mqtt:
@@ -16,4 +17,7 @@
         keepAlive: 60
         caFile: myPath
       http:
-        verify: true    
+        verify: true
+        additionalHeaders:
+          hello: world
+          name: tom


### PR DESCRIPTION
Changes required in order to use the client in the new MAS Connect UI.

Adds support for 2 new operations in StateClient:
 - `patchOperationDeviceType`
 - `getDeviceTypesByLogicalInterfaceId`

Adds support for 2 new (optional) configuration parameters:
 - `http.additionalHeaders`
 - `apiRoot` (defaults to previous value of `api/v0002`)