### PR TITLE
Fix to status console webpack

### DIFF
--- a/samples/webpack/statusconsole/webpack.config.js
+++ b/samples/webpack/statusconsole/webpack.config.js
@@ -14,5 +14,9 @@ module.exports = {
         exclude: /node_modules/
       }
     ]
-  }
+  },
+  externals: {
+    fs: "commonjs fs"
+    //resolves webpack not calling FS as a module but as an environmental object
+  },
 };


### PR DESCRIPTION
Resolves "Error: Can't resolve 'fs'" in the statusConsole build