### PR TITLE
chore: enable OIDC authentication for npm publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -11,6 +11,12 @@ on:
 jobs:
   publish-npm:
     runs-on: ubuntu-latest
+
+    # Required permissions for publishing with provenance
+    permissions:
+      contents: read
+      id-token: write
+      
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -19,7 +25,9 @@ jobs:
           registry-url: https://registry.npmjs.org/
       
       - run: npm i
-      - run: npm run build 
-      - run: npm publish .
+      - run: npm run build
+
+      # Publish to npm with provenance and public access
+      - run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}} 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiotp/sdk",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "description": "SDK for developing device, gateway, and application clients for IBM Watson IoT Platform",
   "main": "dist/index.js",
   "files": [


### PR DESCRIPTION
**Summary**

- Enable OIDC authentication for NPM publishing

**Related Issues**

- fixes: https://jsw.ibm.com/browse/MASMON-6940